### PR TITLE
Fixes a typo in the env-name

### DIFF
--- a/src/util.php
+++ b/src/util.php
@@ -16,7 +16,7 @@ function getDb() {
     if (empty($conn)) {
         $config = new Configuration();
 
-        $db_url = getenv('joinedin_db');
+        $db_url = getenv('joindin_db');
         if (!$db_url) {
             die('No database information has been defined. Be sure to set the \'joindin_db\' environment variable to the Doctrine DB URL to use.');
         }


### PR DESCRIPTION
The documentation states the env-variable is named `joindin_db` but it was actually named `joinedin_db`. Fixes that
